### PR TITLE
chore: bump 5.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "system-designer-electron",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "system-designer-electron",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/remote": "2.1.1"
       },
       "devDependencies": {
         "@electron/universal": "2.0.1",
-        "electron": "28.1.3",
+        "electron": "27.2.4",
         "electron-packager": "16.0.0",
         "electron-packager-languages": "0.5.0"
       }
@@ -219,9 +219,9 @@
       "optional": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.6.tgz",
-      "integrity": "sha512-X36s5CXMrrJOs2lQCdDF68apW4Rfx9ixYMawlepwmE4Anezv/AV2LSpKD1Ub8DAc+urp5bk0BGZ6NtmBitfnsg==",
+      "version": "18.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
+      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-28.1.3.tgz",
-      "integrity": "sha512-NSFyTo6SndTPXzU18XRePv4LnjmuM9rF5GMKta1/kPmi02ISoSRonnD7wUlWXD2x53XyJ6d/TbSVesMW6sXkEQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.2.4.tgz",
+      "integrity": "sha512-oxzd4Aba5N1NrAEubGgRLaYJqA9atmq8Kn61pH7Jc87IXlWaw/G9/Fy6pxZFlGovhZiyjj5WeD7FBWev4ZErmQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
@@ -2361,9 +2361,9 @@
       "optional": true
     },
     "@types/node": {
-      "version": "18.19.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.6.tgz",
-      "integrity": "sha512-X36s5CXMrrJOs2lQCdDF68apW4Rfx9ixYMawlepwmE4Anezv/AV2LSpKD1Ub8DAc+urp5bk0BGZ6NtmBitfnsg==",
+      "version": "18.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
+      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -2675,9 +2675,9 @@
       }
     },
     "electron": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-28.1.3.tgz",
-      "integrity": "sha512-NSFyTo6SndTPXzU18XRePv4LnjmuM9rF5GMKta1/kPmi02ISoSRonnD7wUlWXD2x53XyJ6d/TbSVesMW6sXkEQ==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.2.4.tgz",
+      "integrity": "sha512-oxzd4Aba5N1NrAEubGgRLaYJqA9atmq8Kn61pH7Jc87IXlWaw/G9/Fy6pxZFlGovhZiyjj5WeD7FBWev4ZErmQ==",
       "requires": {
         "@electron/get": "^2.0.0",
         "@types/node": "^18.11.18",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "system-designer-electron",
   "productName": "System Designer",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "buildVersion": "530013",
   "description": "System Designer, a low-code development platform for creating systems",
   "homepage": "https://designfirst.io/systemdesigner/",
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@electron/universal": "2.0.1",
-    "electron": "28.1.3",
+    "electron": "27.2.4",
     "electron-packager": "16.0.0",
     "electron-packager-languages": "0.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "system-designer-electron",
   "productName": "System Designer",
   "version": "5.3.1",
-  "buildVersion": "530013",
+  "buildVersion": "531000",
   "description": "System Designer, a low-code development platform for creating systems",
   "homepage": "https://designfirst.io/systemdesigner/",
   "author": "erwan carriou",


### PR DESCRIPTION
- Due to issue https://github.com/electron/electron/issues/40798, downgrade Electron version to v**27.2.4**.